### PR TITLE
处理多个bug

### DIFF
--- a/example/calendar/js/calendar.js
+++ b/example/calendar/js/calendar.js
@@ -79,14 +79,11 @@
 				ddy = dateObj.getFullYear();
 			};
 			dateObj.setFullYear(ddy);
-			//设置月份之前先判断上一个月有多少天，如果上一个月没有31天且今天有事31号，那就先设置日期为上一个月的天数
-			if(dateObj.getDate()=="31"){
-				if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)=="30"){
-					dateObj.setDate(30);
-				}else if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)< "30"){}{
-					dateObj.setDate(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm));
-				}
-			}				
+			//设置月份之前先判断上个月有多少天,如果上个月天数比当前日期小，就把日期设置为上个月的天数
+			var lastMonthDay = getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm);
+			if(lastMonthDay< dateObj.getDate()){
+				dateObj.setDate(lastMonthDay);
+			}						
 		  	dateObj.setMonth(ddm);
 		  	omonth.innerHTML = getMonth(dateObj)+"月";
 		  	oyear.innerHTML = dateObj.getFullYear()+"年";
@@ -109,14 +106,11 @@
 				ddy = dateObj.getFullYear();
 			};
 			dateObj.setFullYear(ddy);
-			//设置月份之前先判断下一个月有多少天，如果下一个月没有31天且今天有事31号，那就先设置日期为下一个月的天数
-			if(dateObj.getDate()=="31"){
-				if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)=="30"){
-					dateObj.setDate(30);
-				}else if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)< "30"){}{
-					dateObj.setDate(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm));
-				}
-			}				
+			//设置月份之前先判断下一个月有多少天,如果下个月天数比当前日期小，就把日期设置为下个月的天数		
+			var nextMonthDay = getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm);
+			if(nextMonthDay < dateObj.getDate()){
+				dateObj.setDate(nextMonthDay);
+			}			
 			dateObj.setMonth(ddm);
 			omonth.innerHTML = getMonth(dateObj)+"月";
 			oyear.innerHTML = dateObj.getFullYear()+"年";

--- a/example/calendar/js/calendar.js
+++ b/example/calendar/js/calendar.js
@@ -54,13 +54,13 @@
 		}
 		// 显示当前时间
 		content.addEventListener(evt.type,function (event) {
-		    if(event.target.tagName=="DIV" && event.target.nodeType=="1" && hasclass(event.target.className,"canChoose")){
+		    if(event.target.tagName.toLowerCase()=="div" && event.target.nodeType=="1" && hasclass(event.target.className,"canChoose")){
 				var day = event.target.innerHTML;
-				var dateObj = new Date(year, month-1, day);
+				dateObj = new Date(getYear(dateObj), getMonth(dateObj)-1, day);
 				var week = getWeek(dateObj);	
 				opt.callback({
-					'year': year,
-					'month': month,
+					'year': getYear(dateObj),
+					'month':  getMonth(dateObj),
 					'day': day,
 					'week': week
 				});
@@ -79,6 +79,14 @@
 				ddy = dateObj.getFullYear();
 			};
 			dateObj.setFullYear(ddy);
+			//设置月份之前先判断上一个月有多少天，如果上一个月没有31天且今天有事31号，那就先设置日期为上一个月的天数
+			if(dateObj.getDate()=="31"){
+				if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)=="30"){
+					dateObj.setDate(30);
+				}else if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)< "30"){}{
+					dateObj.setDate(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm));
+				}
+			}				
 		  	dateObj.setMonth(ddm);
 		  	omonth.innerHTML = getMonth(dateObj)+"月";
 		  	oyear.innerHTML = dateObj.getFullYear()+"年";
@@ -101,6 +109,14 @@
 				ddy = dateObj.getFullYear();
 			};
 			dateObj.setFullYear(ddy);
+			//设置月份之前先判断下一个月有多少天，如果下一个月没有31天且今天有事31号，那就先设置日期为下一个月的天数
+			if(dateObj.getDate()=="31"){
+				if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)=="30"){
+					dateObj.setDate(30);
+				}else if(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm)< "30"){}{
+					dateObj.setDate(getCurmonDaynum(dateObj,dateObj.getFullYear(),ddm));
+				}
+			}				
 			dateObj.setMonth(ddm);
 			omonth.innerHTML = getMonth(dateObj)+"月";
 			oyear.innerHTML = dateObj.getFullYear()+"年";
@@ -227,9 +243,10 @@
 	}
 	
 	// 获取本月总日数方法
-	function getCurmonDaynum(dateObj){
-		var year=dateObj.getFullYear();
-		var month=dateObj.getMonth();
+	//修改后做了判断，如果传入fullyear 和 curMonth 参数，就可以查询任意年份任一月份有多少天，用于处理31号的问题
+	function getCurmonDaynum(dateObj,fullyear,curMonth) {
+		var year = fullyear?fullyear:dateObj.getFullYear();
+		var month = curMonth?curMonth:dateObj.getMonth();
 		if(isLeapYear(year)){//闰年
 			switch(month) { 
 				case 0: return "31"; break; 
@@ -266,13 +283,14 @@
 	}
 	
 	// 获取本月1号的周值
-	function getCurmonWeeknum(dateObj){
+	function getCurmonWeeknum(dateObj) {
 		var oneyear = new Date();
 		var year = dateObj.getFullYear();
 		var month = dateObj.getMonth(); //0是12月
 		oneyear.setFullYear(year);
-		oneyear.setMonth(month); //0是12月
+		//先设置1号，再改变月份，避免31号的问题
 		oneyear.setDate(1);
-		return oneyear.getDay();  
+		oneyear.setMonth(month); //0是12月
+		return oneyear.getDay();
 	}
 })(window);


### PR DESCRIPTION
1.原有代码切换月份或者年份后，只能获取新选中的是哪一天，年份、月份、星期在切换后获取都有误，已修改。
2.原有代码在进行月份切换时，未考虑当天未31号的情况。比如今天是8月31号，切换下月时，变成了10月1号。是因为dateObj.setMonth(ddm)，当今天为8月31号是，该方法将dateObj变为了9月31号，但是9月是没有31号的，顺延成了10月1号。已修改
3.同上，获取本月1号的周值时，也未考虑31号的问题，先oneyear.setDate(1)，再setMonth()